### PR TITLE
Move Matchers pkg from internal

### DIFF
--- a/matchers/matcher.go
+++ b/matchers/matcher.go
@@ -59,7 +59,7 @@ func NewMatcher(t MatchType, n, v string) (*Matcher, error) {
 		Value: v,
 	}
 	if t == MatchRegexp || t == MatchNotRegexp {
-		re, err := NewFastRegexMatcher(v)
+		re, err := newFastRegexMatcher(v)
 		if err != nil {
 			return nil, err
 		}
@@ -89,9 +89,9 @@ func (m *Matcher) Matches(s string) bool {
 	case MatchNotEqual:
 		return s != m.Value
 	case MatchRegexp:
-		return m.re.MatchString(s)
+		return m.re.matchString(s)
 	case MatchNotRegexp:
-		return !m.re.MatchString(s)
+		return !m.re.matchString(s)
 	}
 	panic("labels.Matcher.Matches: invalid match type")
 }

--- a/matchers/regexp.go
+++ b/matchers/regexp.go
@@ -29,7 +29,7 @@ type FastRegexMatcher struct {
 	contains string
 }
 
-func NewFastRegexMatcher(v string) (*FastRegexMatcher, error) {
+func newFastRegexMatcher(v string) (*FastRegexMatcher, error) {
 	re, err := regexp.Compile("^(?:" + v + ")$")
 	if err != nil {
 		return nil, err
@@ -51,7 +51,7 @@ func NewFastRegexMatcher(v string) (*FastRegexMatcher, error) {
 	return m, nil
 }
 
-func (m *FastRegexMatcher) MatchString(s string) bool {
+func (m *FastRegexMatcher) matchString(s string) bool {
 	if m.prefix != "" && !strings.HasPrefix(s, m.prefix) {
 		return false
 	}

--- a/metrics.go
+++ b/metrics.go
@@ -6,7 +6,7 @@ package e2e
 import (
 	"math"
 
-	"github.com/efficientgo/e2e/internal/matchers"
+	"github.com/efficientgo/e2e/matchers"
 	io_prometheus_client "github.com/prometheus/client_model/go"
 )
 


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

Since `matchers` are currently internal package, it cannot be used when importing `e2e` and thus making it not possible to use matchers for metrics option.

Resolves #7.