### PR TITLE
Docker runnable start: Wait for image download if not available

### DIFF
--- a/env.go
+++ b/env.go
@@ -70,11 +70,12 @@ type StartOptions struct {
 	Command   Command
 	Readiness ReadinessProbe
 	// WaitReadyBackofff represents backoff used for WaitReady.
-	WaitReadyBackoff *backoff.Config
-	Volumes          []string
-	UserNs           string
-	Privileged       bool
-	Capabilities     []RunnableCapabilities
+	WaitReadyBackoff    *backoff.Config
+	WaitDownloadBackoff *backoff.Config
+	Volumes             []string
+	UserNs              string
+	Privileged          bool
+	Capabilities        []RunnableCapabilities
 }
 
 type RunnableCapabilities string


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

Currently the `Start` method for a Docker runnable is checking for the container readiness straight away. However, in case the Docker image is not available locally, it has to be downloaded first, which can also take considerable time and can cause the readiness-check loop to time out. This PR adds a separate step in the process to check whether the image is available, and if not, to wait for it to download.

Resolves #3 