### PR TITLE
monitoring: allow compilation for non-Linux

### DIFF
--- a/monitoring/cgroups_linux.go
+++ b/monitoring/cgroups_linux.go
@@ -1,0 +1,105 @@
+// Copyright (c) The EfficientGo Authors.
+// Licensed under the Apache License 2.0.
+
+//go:build linux
+// +build linux
+
+package e2emonitoring
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/containerd/cgroups"
+	"github.com/efficientgo/e2e"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
+)
+
+const (
+	mountpoint     = "/sys/fs/cgroup"
+	cgroupSubGroup = "e2e"
+)
+
+func setupPIDAsContainer(env e2e.Environment, pid int) ([]string, error) {
+	// Try to setup test cgroup to check if we have perms.
+	{
+		c, err := cgroups.New(cgroups.V1, cgroups.StaticPath(filepath.Join(cgroupSubGroup, "__test__")), &specs.LinuxResources{})
+		if err != nil {
+			if !os.IsPermission(err) {
+				return nil, err
+			}
+
+			uid := os.Getuid()
+
+			var cmds []string
+
+			ss, cerr := cgroups.V1()
+			if cerr != nil {
+				return nil, cerr
+			}
+
+			for _, s := range ss {
+				cmds = append(cmds, fmt.Sprintf("sudo mkdir -p %s && sudo chown -R %d %s",
+					filepath.Join(mountpoint, string(s.Name()), cgroupSubGroup),
+					uid,
+					filepath.Join(mountpoint, string(s.Name()), cgroupSubGroup),
+				))
+			}
+			return nil, errors.Errorf("e2e does not have permissions, run following command: %q; err: %v", strings.Join(cmds, " && "), err)
+		}
+		if err := c.Delete(); err != nil {
+			return nil, err
+		}
+	}
+
+	// Delete previous cgroup if it exists.
+	root, err := cgroups.Load(cgroups.V1, cgroups.RootPath)
+	if err != nil {
+		return nil, err
+	}
+
+	l, err := cgroups.Load(cgroups.V1, cgroups.StaticPath(filepath.Join(cgroupSubGroup, env.Name())))
+	if err != nil {
+		if err != cgroups.ErrCgroupDeleted {
+			return nil, err
+		}
+	} else {
+		if err := l.MoveTo(root); err != nil {
+			return nil, err
+		}
+		if err := l.Delete(); err != nil {
+			return nil, err
+		}
+	}
+
+	// Create cgroup that will contain our process.
+	c, err := cgroups.New(cgroups.V1, cgroups.StaticPath(filepath.Join(cgroupSubGroup, env.Name())), &specs.LinuxResources{})
+	if err != nil {
+		return nil, err
+	}
+	if err := c.Add(cgroups.Process{Pid: pid}); err != nil {
+		return nil, err
+	}
+	env.AddCloser(func() {
+		l, err := cgroups.Load(cgroups.V1, cgroups.StaticPath(filepath.Join(cgroupSubGroup, env.Name())))
+		if err != nil {
+			if err != cgroups.ErrCgroupDeleted {
+				// All good.
+				return
+			}
+			fmt.Println("Failed to load cgroup", err)
+		}
+		if err := l.MoveTo(root); err != nil {
+			fmt.Println("Failed to move all processes", err)
+		}
+		if err := c.Delete(); err != nil {
+			// TODO(bwplotka): This never works, but not very important, fix it.
+			fmt.Println("Failed to delete cgroup", err)
+		}
+	})
+
+	return []string{filepath.Join("/", cgroupSubGroup, env.Name())}, nil
+}

--- a/monitoring/cgroups_nolinux.go
+++ b/monitoring/cgroups_nolinux.go
@@ -1,0 +1,16 @@
+// Copyright (c) The EfficientGo Authors.
+// Licensed under the Apache License 2.0.
+
+//go:build !linux
+// +build !linux
+
+package e2emonitoring
+
+import (
+	"github.com/efficientgo/e2e"
+	"github.com/pkg/errors"
+)
+
+func setupPIDAsContainer(env e2e.Environment, pid int) ([]string, error) {
+	return nil, errors.New("not implemented")
+}

--- a/monitoring/monitoring.go
+++ b/monitoring/monitoring.go
@@ -4,23 +4,19 @@
 package e2emonitoring
 
 import (
-	"fmt"
 	"net"
 	"net/http"
 	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
 
-	"github.com/containerd/cgroups"
 	"github.com/efficientgo/e2e"
 	e2edb "github.com/efficientgo/e2e/db"
 	e2einteractive "github.com/efficientgo/e2e/interactive"
 	"github.com/efficientgo/e2e/monitoring/promconfig"
 	sdconfig "github.com/efficientgo/e2e/monitoring/promconfig/discovery/config"
 	"github.com/efficientgo/e2e/monitoring/promconfig/discovery/targetgroup"
-	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -225,90 +221,4 @@ func newCadvisor(env e2e.Environment, name string, cgroupPrefixes ...string) *e2
 		UserNs:     "host",
 		Privileged: true,
 	})
-}
-
-const (
-	mountpoint     = "/sys/fs/cgroup"
-	cgroupSubGroup = "e2e"
-)
-
-func setupPIDAsContainer(env e2e.Environment, pid int) ([]string, error) {
-	// Try to setup test cgroup to check if we have perms.
-	{
-		c, err := cgroups.New(cgroups.V1, cgroups.StaticPath(filepath.Join(cgroupSubGroup, "__test__")), &specs.LinuxResources{})
-		if err != nil {
-			if !os.IsPermission(err) {
-				return nil, err
-			}
-
-			uid := os.Getuid()
-
-			var cmds []string
-
-			ss, cerr := cgroups.V1()
-			if cerr != nil {
-				return nil, cerr
-			}
-
-			for _, s := range ss {
-				cmds = append(cmds, fmt.Sprintf("sudo mkdir -p %s && sudo chown -R %d %s",
-					filepath.Join(mountpoint, string(s.Name()), cgroupSubGroup),
-					uid,
-					filepath.Join(mountpoint, string(s.Name()), cgroupSubGroup),
-				))
-			}
-			return nil, errors.Errorf("e2e does not have permissions, run following command: %q; err: %v", strings.Join(cmds, " && "), err)
-		}
-		if err := c.Delete(); err != nil {
-			return nil, err
-		}
-	}
-
-	// Delete previous cgroup if it exists.
-	root, err := cgroups.Load(cgroups.V1, cgroups.RootPath)
-	if err != nil {
-		return nil, err
-	}
-
-	l, err := cgroups.Load(cgroups.V1, cgroups.StaticPath(filepath.Join(cgroupSubGroup, env.Name())))
-	if err != nil {
-		if err != cgroups.ErrCgroupDeleted {
-			return nil, err
-		}
-	} else {
-		if err := l.MoveTo(root); err != nil {
-			return nil, err
-		}
-		if err := l.Delete(); err != nil {
-			return nil, err
-		}
-	}
-
-	// Create cgroup that will contain our process.
-	c, err := cgroups.New(cgroups.V1, cgroups.StaticPath(filepath.Join(cgroupSubGroup, env.Name())), &specs.LinuxResources{})
-	if err != nil {
-		return nil, err
-	}
-	if err := c.Add(cgroups.Process{Pid: pid}); err != nil {
-		return nil, err
-	}
-	env.AddCloser(func() {
-		l, err := cgroups.Load(cgroups.V1, cgroups.StaticPath(filepath.Join(cgroupSubGroup, env.Name())))
-		if err != nil {
-			if err != cgroups.ErrCgroupDeleted {
-				// All good.
-				return
-			}
-			fmt.Println("Failed to load cgroup", err)
-		}
-		if err := l.MoveTo(root); err != nil {
-			fmt.Println("Failed to move all processes", err)
-		}
-		if err := c.Delete(); err != nil {
-			// TODO(bwplotka): This never works, but not very important, fix it.
-			fmt.Println("Failed to delete cgroup", err)
-		}
-	})
-
-	return []string{filepath.Join("/", cgroupSubGroup, env.Name())}, nil
 }


### PR DESCRIPTION
This commit extracts the Linux-specific code into files that are guarded
by Golang build flags, allowing binaries that import the e2e/monitoring
package to compile on non-Linux operating systems. I tested this with
the following `main.go` and was able to compile a binary for both Darwin
and Windows:
```golang
package main

import (
	"fmt"

	m "github.com/efficientgo/e2e/monitoring"
)

func main() {
	s := m.Service{}
	fmt.Println(s)
}
```

Fixes: https://github.com/efficientgo/e2e/issues/15

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>