### PR TITLE
Make minio SSE using KMS optional

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -42,7 +42,7 @@ func WithFlagOverride(ov map[string]string) Option {
 const AccessPortName = "http"
 
 // NewMinio returns minio server, used as a local replacement for S3.
-func NewMinio(env e2e.Environment, name, bktName string, opts ...Option) e2e.InstrumentedRunnable {
+func NewMinio(env e2e.Environment, name, bktName string, sse bool, opts ...Option) e2e.InstrumentedRunnable {
 	o := options{image: "minio/minio:RELEASE.2022-03-14T18-25-24Z"}
 	for _, opt := range opts {
 		opt(&o)
@@ -55,25 +55,32 @@ func NewMinio(env e2e.Environment, name, bktName string, opts ...Option) e2e.Ins
 		"MINIO_ROOT_PASSWORD=" + MinioSecretKey,
 		"MINIO_BROWSER=" + "off",
 		"ENABLE_HTTPS=" + "0",
-		// https://docs.min.io/docs/minio-kms-quickstart-guide.html
-		"MINIO_KMS_KES_ENDPOINT=" + "https://play.min.io:7373",
-		"MINIO_KMS_KES_KEY_FILE=" + "root.key",
-		"MINIO_KMS_KES_CERT_FILE=" + "root.cert",
-		"MINIO_KMS_KES_KEY_NAME=" + "my-minio-key",
 	}
+
 	f := e2e.NewInstrumentedRunnable(env, name).WithPorts(ports, AccessPortName).Future()
+
+	// Hacky: Create user that matches ID with host ID to be able to remove .minio.sys details on the start.
+	// Proper solution would be to contribute/create our own minio image which is non root.
+	command := fmt.Sprintf("useradd -G root -u %v me && mkdir -p %s && chown -R me %s &&", userID, f.InternalDir(), f.InternalDir())
+
+	if sse {
+		envVars = append(envVars, []string{
+			// https://docs.min.io/docs/minio-kms-quickstart-guide.html
+			"MINIO_KMS_KES_ENDPOINT=" + "https://play.min.io:7373",
+			"MINIO_KMS_KES_KEY_FILE=" + "root.key",
+			"MINIO_KMS_KES_CERT_FILE=" + "root.cert",
+			"MINIO_KMS_KES_KEY_NAME=" + "my-minio-key",
+		}...)
+		command += "curl -sSL --tlsv1.3 -O 'https://raw.githubusercontent.com/minio/kes/master/root.key' -O 'https://raw.githubusercontent.com/minio/kes/master/root.cert' && cp root.* /home/me/ && "
+	}
+
 	return f.Init(
 		e2e.StartOptions{
 			Image: o.image,
 			// Create the required bucket before starting minio.
-			Command: e2e.NewCommandWithoutEntrypoint("sh", "-c", fmt.Sprintf(
-				// Hacky: Create user that matches ID with host ID to be able to remove .minio.sys details on the start.
-				// Proper solution would be to contribute/create our own minio image which is non root.
-				"useradd -G root -u %v me && mkdir -p %s && chown -R me %s &&"+
-					"curl -sSL --tlsv1.2 -O 'https://raw.githubusercontent.com/minio/kes/master/root.key' -O 'https://raw.githubusercontent.com/minio/kes/master/root.cert' && "+
-					"cp root.* /home/me/ && "+
-					"su - me -s /bin/sh -c 'mkdir -p %s && %s /opt/bin/minio server --address :%v --quiet %v'",
-				userID, f.InternalDir(), f.InternalDir(), filepath.Join(f.InternalDir(), bktName), strings.Join(envVars, " "), ports[AccessPortName], f.InternalDir()),
+			Command: e2e.NewCommandWithoutEntrypoint("sh", "-c", command+fmt.Sprintf(
+				"su - me -s /bin/sh -c 'mkdir -p %s && %s /opt/bin/minio server --address :%v --quiet %v'",
+				filepath.Join(f.InternalDir(), bktName), strings.Join(envVars, " "), ports[AccessPortName], f.InternalDir()),
 			),
 			Readiness: e2e.NewHTTPReadinessProbe(AccessPortName, "/minio/health/live", 200, 200),
 		},


### PR DESCRIPTION
Currently, `NewMinio` always runs minio with SSE-S3 enabled using KMS as defined in https://docs.min.io/docs/minio-kms-quickstart-guide.html. 

This results in dependency on both GitHub (for key and cert) and https://play.min.io:7373, just to start minio container for any e2e test as discussed in https://github.com/observatorium/rules-objstore/pull/9#discussion_r840588813. The test also cannot be run without active net connection.

SSE-S3 encryption for minio isn't commonly used for e2e tests for eg in [Thanos](https://github.com/thanos-io/thanos/blob/9ec283dbea39be1708401eed2830e40a05f6d46a/test/e2e/e2ethanos/services.go#L1024) and [Observatorium API](https://github.com/observatorium/api/blob/main/test/e2e/configs.go#L177), so this PR makes it optional with the default being SSE turned off. :)

Instead of a boolean argument in `NewMinio`, it  adds a `minioOptions` field to `Options` struct, to allow for defining dedicated configuration options for minio. So we can use it to enable KMS for minio like so,
`m := e2edb.NewMinio(e, "rules-minio", bucket, e2edb.WithMinioSSE())`

This can be added for other containers and options in the future. WDYT? :)