### PR TITLE
Fixed support for local images.

### DIFF
--- a/env_docker.go
+++ b/env_docker.go
@@ -602,6 +602,11 @@ func (d *dockerRunnable) prePullImage(ctx context.Context) (err error) {
 		return errors.Errorf("service %s is running; expected stopped", d.Name())
 	}
 
+	if _, err = d.env.execContext(ctx, "docker", "image", "inspect", d.opts.Image).CombinedOutput(); err == nil {
+		return nil
+	}
+
+	// Assuming Error: No such image: <image>.
 	cmd := d.env.execContext(ctx, "docker", "pull", d.opts.Image)
 	l := &LinePrefixLogger{prefix: d.Name() + ": ", logger: d.logger}
 	cmd.Stdout = l


### PR DESCRIPTION
Problem: Explicit download of images fail if you build local image with tag that fakes some upstream image.

Signed-off-by: Bartlomiej Plotka <bwplotka@gmail.com>