### PR TITLE
Fix infinite loop on waiting for metrics

### DIFF
--- a/instrumented.go
+++ b/instrumented.go
@@ -169,6 +169,7 @@ func (r *instrumentedRunnable) WaitSumMetricsWithOptions(expected MetricValueExp
 	for metricsWaitBackoff.Reset(); metricsWaitBackoff.Ongoing(); {
 		sums, err = r.SumMetrics(metricNames, opts...)
 		if options.waitMissingMetrics && errors.Is(err, errMissingMetric) {
+			metricsWaitBackoff.Wait()
 			continue
 		}
 		if err != nil {

--- a/instrumented_composite.go
+++ b/instrumented_composite.go
@@ -57,6 +57,7 @@ func (r *CompositeInstrumentedRunnable) WaitSumMetricsWithOptions(expected Metri
 	for r.backoff.Reset(); r.backoff.Ongoing(); {
 		sums, err = r.SumMetrics(metricNames, opts...)
 		if options.waitMissingMetrics && errors.Is(err, errMissingMetric) {
+			r.backoff.Wait()
 			continue
 		}
 		if err != nil {

--- a/instrumented_test.go
+++ b/instrumented_test.go
@@ -95,6 +95,7 @@ metric_b_summary_count 1
 		MaxRetries: 1,
 	}
 	testutil.NotOk(t, s.WaitSumMetricsWithOptions(Equals(16), []string{"metric_a"}, WithWaitBackoff(&noRetryWaitBackoff)))
+	testutil.NotOk(t, s.WaitSumMetricsWithOptions(Equals(16), []string{"unknown_metric"}, WaitMissingMetrics()))
 
 	testutil.Ok(t, s.WaitSumMetricsWithOptions(Equals(1000), []string{"metric_b"}, WithWaitBackoff(&noRetryWaitBackoff)))
 	testutil.Ok(t, s.WaitSumMetricsWithOptions(Equals(1020), []string{"metric_b_counter"}, WithWaitBackoff(&noRetryWaitBackoff)))
@@ -172,53 +173,4 @@ metric_b 1000
 		MaxRetries: 50,
 	})
 	testutil.Ok(t, s.WaitSumMetrics(Equals(math.NaN()), "metric_a"))
-}
-
-func TestWaitSumMetric_DoesNotWaitForever(t *testing.T) {
-	// Listen on a random port before starting the HTTP server, to
-	// make sure the port is already open when we'll call WaitSumMetric()
-	// the first time (this avoid flaky tests).
-	ln, err := net.Listen("tcp", "localhost:0")
-	testutil.Ok(t, err)
-	defer ln.Close()
-
-	// Get the port.
-	_, addrPort, err := net.SplitHostPort(ln.Addr().String())
-	testutil.Ok(t, err)
-
-	port, err := strconv.Atoi(addrPort)
-	testutil.Ok(t, err)
-
-	// Start an HTTP server exposing the metrics.
-	srv := &http.Server{
-		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			_, _ = w.Write([]byte(`
-# HELP metric_c cheescake
-# TYPE metric_c GAUGE
-metric_c 20
-`))
-		}),
-	}
-	defer srv.Close()
-
-	go func() {
-		_ = srv.Serve(ln)
-	}()
-
-	r := &dockerRunnable{
-		hostPorts:       map[string]int{"http": port},
-		usedNetworkName: "hack",
-	}
-	s := &instrumentedRunnable{
-		metricPortName: "http",
-		runnable:       r,
-		Linkable:       r,
-	}
-
-	s.waitBackoff = backoff.New(context.Background(), backoff.Config{
-		Min:        300 * time.Millisecond,
-		Max:        600 * time.Millisecond,
-		MaxRetries: 50,
-	})
-	testutil.NotOk(t, s.WaitSumMetricsWithOptions(Equals(1), []string{"metric_a"}, WaitMissingMetrics()))
 }


### PR DESCRIPTION
When using `WaitSumMetricsWithOptions` together with the `WaitMissingMetrics` option it now counts towards the metrics backoff, which eventually will stop the wait instead of looping forever.


Fixes #38.
