### PR TITLE
Upgrade cadvisor to multi-arch image

### DIFF
--- a/monitoring/monitoring.go
+++ b/monitoring/monitoring.go
@@ -251,7 +251,7 @@ func newCadvisor(env e2e.Environment, name string, cgroupPrefixes ...string) e2e
 			"--docker_only=true",
 			"--raw_cgroup_prefix_whitelist="+strings.Join(cgroupPrefixes, ","),
 		),
-		Image: "gcr.io/cadvisor/cadvisor:v0.44.0",
+		Image: "gcr.io/cadvisor/cadvisor:v0.45.0",
 		// See https://github.com/google/cadvisor/blob/master/docs/running.md.
 		Volumes: []string{
 			"/:/rootfs:ro",


### PR DESCRIPTION
[v0.45.0](https://console.cloud.google.com/gcr/images/cadvisor/global/cadvisor@sha256:9360d7421c5e9b646ea13e5ced3f8e6da80017b0144733a04b7401dd8c01a5cb/details?tab=pull) is a multi-arch image manifest. 

[v0.44.0](https://console.cloud.google.com/gcr/images/cadvisor/GLOBAL/cadvisor@sha256:ef1e224267584fc9cb8d189867f178598443c122d9068686f9c3898c735b711f/details?tag=v0.44.0&tab=pull) is only x86_64. 