### PR TITLE
Use a more well known macOS Docker host address

### DIFF
--- a/env_docker.go
+++ b/env_docker.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	dockerLocalSharedDir   = "/shared"
-	dockerMacOSGatewayAddr = "gateway.docker.internal"
+	dockerMacOSGatewayAddr = "host.docker.internal"
 )
 
 var (


### PR DESCRIPTION
`host.docker.internal` is the recommended option according to [Docker's docs](https://docs.docker.com/desktop/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host).

 `gateway.docker.internal` is a secondary address and is not implemented in all OSS alternatives to Docker Desktop (i.e. in Rancher Desktop, see https://github.com/rancher-sandbox/rancher-desktop/issues/1767).

This fixes the meta-monitoring Prometheus for users of Rancher Desktop, while also being compatible with both Docker Desktop and Podman.