### PR TITLE
Improve WSL 2 experience

### DIFF
--- a/env.go
+++ b/env.go
@@ -80,6 +80,8 @@ type Environment interface {
 	AddCloser(func())
 	// Close shutdowns isolated environment and cleans its resources.
 	Close()
+	// WSL2 returns true if the environment is WSL2.
+	WSL2() bool
 }
 
 type EnvironmentListener interface {

--- a/env.go
+++ b/env.go
@@ -80,8 +80,6 @@ type Environment interface {
 	AddCloser(func())
 	// Close shutdowns isolated environment and cleans its resources.
 	Close()
-	// WSL2 returns true if the environment is WSL2.
-	WSL2() bool
 }
 
 type EnvironmentListener interface {

--- a/env_docker.go
+++ b/env_docker.go
@@ -9,6 +9,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"github.com/efficientgo/e2e/host"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -20,7 +21,6 @@ import (
 
 	"github.com/efficientgo/core/backoff"
 	"github.com/efficientgo/core/errors"
-	e2einteractive "github.com/efficientgo/e2e/interactive"
 )
 
 const (
@@ -130,10 +130,10 @@ func New(opts ...EnvironmentOption) (_ *DockerEnvironment, err error) {
 		return nil, errors.Wrapf(err, "create docker network '%s'", d.networkName)
 	}
 
-	switch e2einteractive.HostOSPlatform() {
+	switch host.OSPlatform() {
 	case "darwin", "WSL2":
 		d.hostAddr = dockerGatewayAddr
-	case "linux":
+	default: // the "linux" behavior is default
 		out, err := d.exec("docker", "network", "inspect", d.networkName).CombinedOutput()
 		if err != nil {
 			e.logger.Log(string(out))

--- a/env_docker.go
+++ b/env_docker.go
@@ -130,15 +130,10 @@ func New(opts ...EnvironmentOption) (_ *DockerEnvironment, err error) {
 		return nil, errors.Wrapf(err, "create docker network '%s'", d.networkName)
 	}
 
-	switch runtime.GOOS {
-	case "darwin":
+	switch e2einteractive.HostOSPlatform() {
+	case "darwin", "WSL2":
 		d.hostAddr = dockerGatewayAddr
-	default:
-		inWSL, _ := e2einteractive.WSL2()
-		if inWSL {
-			d.hostAddr = dockerGatewayAddr
-			break
-		}
+	case "linux":
 		out, err := d.exec("docker", "network", "inspect", d.networkName).CombinedOutput()
 		if err != nil {
 			e.logger.Log(string(out))

--- a/env_docker.go
+++ b/env_docker.go
@@ -9,7 +9,6 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
-	"github.com/efficientgo/e2e/host"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -18,6 +17,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/efficientgo/e2e/host"
 
 	"github.com/efficientgo/core/backoff"
 	"github.com/efficientgo/core/errors"

--- a/env_docker.go
+++ b/env_docker.go
@@ -134,8 +134,7 @@ func New(opts ...EnvironmentOption) (_ *DockerEnvironment, err error) {
 	case "darwin":
 		d.hostAddr = dockerGatewayAddr
 	default:
-		inWSL2 := d.WSL2()
-		if inWSL2 {
+		if d.WSL2() {
 			d.hostAddr = dockerGatewayAddr
 			break
 		}

--- a/env_docker.go
+++ b/env_docker.go
@@ -134,7 +134,8 @@ func New(opts ...EnvironmentOption) (_ *DockerEnvironment, err error) {
 	case "darwin":
 		d.hostAddr = dockerGatewayAddr
 	default:
-		if d.WSL2() {
+		inWSL, _ := e2einteractive.WSL2()
+		if inWSL {
 			d.hostAddr = dockerGatewayAddr
 			break
 		}
@@ -170,15 +171,6 @@ func (e *DockerEnvironment) Name() string     { return e.networkName }
 
 func (e *DockerEnvironment) AddCloser(f func()) {
 	e.closers = append(e.closers, f)
-}
-
-func (e *DockerEnvironment) WSL2() bool {
-	inWSL, err := e2einteractive.WSL2()
-	if err != nil {
-		e.logger.Log(err)
-		return false
-	}
-	return inWSL
 }
 
 func (e *DockerEnvironment) Runnable(name string) RunnableBuilder {

--- a/host/host.go
+++ b/host/host.go
@@ -9,6 +9,7 @@ import (
 // OSPlatform returns the host's OS platform akin to `runtime.GOOS`, with
 // added awareness of Windows Subsystem for Linux (WSL) 2 environments.
 // The possible values are the same as `runtime.GOOS`, plus "WSL2".
+// TODO: move this to a new home, potentially github.com/efficientgo/core.
 func OSPlatform() string {
 	if isWSL2() {
 		return "WSL2"

--- a/host/host.go
+++ b/host/host.go
@@ -1,0 +1,28 @@
+package host
+
+import (
+	"bytes"
+	"os"
+	"runtime"
+)
+
+// OSPlatform returns the host's OS platform akin to `runtime.GOOS`, with
+// added awareness of Windows Subsystem for Linux (WSL) 2 environments.
+// The possible values are the same as `runtime.GOOS`, plus "WSL2".
+func OSPlatform() string {
+	if isWSL2() {
+		return "WSL2"
+	}
+	return runtime.GOOS
+}
+
+func isWSL2() bool {
+	if runtime.GOOS != "linux" {
+		return false
+	}
+	version, err := os.ReadFile("/proc/version")
+	if err != nil {
+		return false
+	}
+	return bytes.Contains(version, []byte("WSL2"))
+}

--- a/host/host.go
+++ b/host/host.go
@@ -1,3 +1,6 @@
+// Copyright (c) The EfficientGo Authors.
+// Licensed under the Apache License 2.0.
+
 package host
 
 import (

--- a/interactive/interactive.go
+++ b/interactive/interactive.go
@@ -6,7 +6,6 @@ package e2einteractive
 import (
 	"context"
 	"fmt"
-	"github.com/efficientgo/e2e/host"
 	"net"
 	"net/http"
 	"os"
@@ -14,6 +13,8 @@ import (
 	"os/signal"
 	"sync"
 	"syscall"
+
+	"github.com/efficientgo/e2e/host"
 
 	"github.com/efficientgo/core/errors"
 )

--- a/interactive/interactive.go
+++ b/interactive/interactive.go
@@ -39,8 +39,8 @@ func OpenInBrowser(url string) error {
 }
 
 // HostOSPlatform returns the host's OS platform akin to `runtime.GOOS`, with
-// added awareness of WSL 2 environments. The possible values are the same as
-// `runtime.GOOS` plus "WSL2".
+// added awareness of Windows Subsystem for Linux (WSL) 2 environments.
+// The possible values are the same as `runtime.GOOS`, plus "WSL2".
 func HostOSPlatform() string {
 	if wsl2() {
 		return "WSL2"

--- a/interactive/interactive.go
+++ b/interactive/interactive.go
@@ -46,7 +46,7 @@ func WSL2() (bool, error) {
 	}
 	version, err := os.ReadFile("/proc/version")
 	if err != nil {
-		return false, errors.Wrapf(err, "detecting WSL2: %s", string(out))
+		return false, errors.Wrapf(err, "detecting WSL2: %s", string(version))
 	}
 	return bytes.Contains(version, []byte("WSL2")), nil
 }

--- a/interactive/interactive.go
+++ b/interactive/interactive.go
@@ -44,11 +44,11 @@ func WSL2() (bool, error) {
 	if runtime.GOOS != "linux" {
 		return false, nil
 	}
-	out, err := exec.Command("cat", "/proc/version").CombinedOutput()
+	version, err := os.ReadFile("/proc/version")
 	if err != nil {
 		return false, errors.Wrapf(err, "detecting WSL2: %s", string(out))
 	}
-	return bytes.Contains(out, []byte("WSL2")), nil
+	return bytes.Contains(version, []byte("WSL2")), nil
 }
 
 // RunUntilEndpointHit stalls current goroutine executions and prints the URL to local address. When URL is hit

--- a/interactive/interactive.go
+++ b/interactive/interactive.go
@@ -4,15 +4,14 @@
 package e2einteractive
 
 import (
-	"bytes"
 	"context"
 	"fmt"
+	"github.com/efficientgo/e2e/host"
 	"net"
 	"net/http"
 	"os"
 	"os/exec"
 	"os/signal"
-	"runtime"
 	"sync"
 	"syscall"
 
@@ -23,7 +22,7 @@ import (
 func OpenInBrowser(url string) error {
 	fmt.Println("Opening", url, "in browser.")
 	var err error
-	switch HostOSPlatform() {
+	switch host.OSPlatform() {
 	case "WSL2":
 		err = exec.Command("rundll32.exe", "url.dll,FileProtocolHandler", url).Run()
 	case "linux":
@@ -36,27 +35,6 @@ func OpenInBrowser(url string) error {
 		err = errors.New("unsupported platform")
 	}
 	return err
-}
-
-// HostOSPlatform returns the host's OS platform akin to `runtime.GOOS`, with
-// added awareness of Windows Subsystem for Linux (WSL) 2 environments.
-// The possible values are the same as `runtime.GOOS`, plus "WSL2".
-func HostOSPlatform() string {
-	if wsl2() {
-		return "WSL2"
-	}
-	return runtime.GOOS
-}
-
-func wsl2() bool {
-	if runtime.GOOS != "linux" {
-		return false
-	}
-	version, err := os.ReadFile("/proc/version")
-	if err != nil {
-		return false
-	}
-	return bytes.Contains(version, []byte("WSL2"))
 }
 
 // RunUntilEndpointHit stalls current goroutine executions and prints the URL to local address. When URL is hit

--- a/monitoring/monitoring.go
+++ b/monitoring/monitoring.go
@@ -265,7 +265,8 @@ func Start(env e2e.Environment, opts ...Option) (_ *Service, err error) {
 	// end up only binding to the IPv6 in the WSL host, which later cannot be acessed
 	// via IPv4 to confirm Prometheus can scrape the local endpoint.
 	// Explicitly asking for an IPv4 listener works.
-	if env.WSL2() {
+	inWSL, _ := e2einteractive.WSL2()
+	if inWSL {
 		networkType = "tcp4"
 	}
 	list, err := net.Listen(networkType, "0.0.0.0:0")
@@ -290,7 +291,7 @@ func Start(env e2e.Environment, opts ...Option) (_ *Service, err error) {
 	env.AddListener(l)
 
 	if opt.useCadvisor {
-		if env.WSL2() {
+		if inWSL {
 			return nil, errors.New("cadvisor is not supported in WSL 2 environments")
 		}
 		c := newCadvisor(env, "cadvisor")

--- a/monitoring/monitoring.go
+++ b/monitoring/monitoring.go
@@ -260,7 +260,16 @@ func Start(env e2e.Environment, opts ...Option) (_ *Service, err error) {
 	}))
 
 	// Listen on all addresses, since we need to connect to it from docker container.
-	list, err := net.Listen("tcp", "0.0.0.0:0")
+	networkType := "tcp"
+	// For unknown reasons, when using WSL 2, if the network type is "tcp" it will
+	// end up only binding to the IPv6 in the WSL host, which later cannot be acessed
+	// via IPv4 to confirm Prometheus can scrape the local endpoint.
+	// Explicitly asking for an IPv4 listener works.
+	wsl2 := env.WSL2()
+	if wsl2 {
+		networkType = "tcp4"
+	}
+	list, err := net.Listen(networkType, "0.0.0.0:0")
 	if err != nil {
 		return nil, err
 	}

--- a/monitoring/monitoring.go
+++ b/monitoring/monitoring.go
@@ -265,8 +265,7 @@ func Start(env e2e.Environment, opts ...Option) (_ *Service, err error) {
 	// end up only binding to the IPv6 in the WSL host, which later cannot be acessed
 	// via IPv4 to confirm Prometheus can scrape the local endpoint.
 	// Explicitly asking for an IPv4 listener works.
-	inWSL, _ := e2einteractive.WSL2()
-	if inWSL {
+	if e2einteractive.HostOSPlatform() == "WSL2" {
 		networkType = "tcp4"
 	}
 	list, err := net.Listen(networkType, "0.0.0.0:0")

--- a/monitoring/monitoring.go
+++ b/monitoring/monitoring.go
@@ -291,7 +291,7 @@ func Start(env e2e.Environment, opts ...Option) (_ *Service, err error) {
 	env.AddListener(l)
 
 	if opt.useCadvisor {
-		if inWSL {
+		if e2einteractive.HostOSPlatform() == "WSL2" {
 			return nil, errors.New("cadvisor is not supported in WSL 2 environments")
 		}
 		c := newCadvisor(env, "cadvisor")

--- a/monitoring/monitoring.go
+++ b/monitoring/monitoring.go
@@ -5,7 +5,6 @@ package e2emon
 
 import (
 	"fmt"
-	"github.com/efficientgo/e2e/host"
 	"io"
 	"net"
 	"net/http"
@@ -15,6 +14,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/efficientgo/e2e/host"
 
 	"github.com/efficientgo/core/errcapture"
 	"github.com/efficientgo/core/errors"

--- a/monitoring/monitoring.go
+++ b/monitoring/monitoring.go
@@ -259,12 +259,12 @@ func Start(env e2e.Environment, opts ...Option) (_ *Service, err error) {
 		h.ServeHTTP(w, req)
 	}))
 
-	// Listen on all addresses, since we need to connect to it from docker container.
-	networkType := "tcp"
+	// Listen on all tcp4 addresses, since we need to connect to it from Docker container.
 	// For unknown reasons, when using WSL 2, if the network type is "tcp" it will
 	// end up only binding to the IPv6 in the WSL host, which later cannot be acessed
 	// via IPv4 to confirm Prometheus can scrape the local endpoint.
 	// Explicitly asking for an IPv4 listener works.
+	networkType := "tcp"
 	if e2einteractive.HostOSPlatform() == "WSL2" {
 		networkType = "tcp4"
 	}

--- a/monitoring/monitoring.go
+++ b/monitoring/monitoring.go
@@ -291,6 +291,9 @@ func Start(env e2e.Environment, opts ...Option) (_ *Service, err error) {
 	env.AddListener(l)
 
 	if opt.useCadvisor {
+		if env.WSL2() {
+			return nil, errors.New("cadvisor is not supported in WSL 2 environments")
+		}
 		c := newCadvisor(env, "cadvisor")
 		if err := e2e.StartAndWaitReady(c); err != nil {
 			return nil, errors.Wrap(err, "starting cadvisor and waiting until ready")

--- a/monitoring/monitoring.go
+++ b/monitoring/monitoring.go
@@ -5,6 +5,7 @@ package e2emon
 
 import (
 	"fmt"
+	"github.com/efficientgo/e2e/host"
 	"io"
 	"net"
 	"net/http"
@@ -265,7 +266,7 @@ func Start(env e2e.Environment, opts ...Option) (_ *Service, err error) {
 	// via IPv4 to confirm Prometheus can scrape the local endpoint.
 	// Explicitly asking for an IPv4 listener works.
 	networkType := "tcp"
-	if e2einteractive.HostOSPlatform() == "WSL2" {
+	if host.OSPlatform() == "WSL2" {
 		networkType = "tcp4"
 	}
 	list, err := net.Listen(networkType, "0.0.0.0:0")
@@ -290,7 +291,7 @@ func Start(env e2e.Environment, opts ...Option) (_ *Service, err error) {
 	env.AddListener(l)
 
 	if opt.useCadvisor {
-		if e2einteractive.HostOSPlatform() == "WSL2" {
+		if host.OSPlatform() == "WSL2" {
 			return nil, errors.New("cadvisor is not supported in WSL 2 environments")
 		}
 		c := newCadvisor(env, "cadvisor")

--- a/monitoring/monitoring.go
+++ b/monitoring/monitoring.go
@@ -265,8 +265,7 @@ func Start(env e2e.Environment, opts ...Option) (_ *Service, err error) {
 	// end up only binding to the IPv6 in the WSL host, which later cannot be acessed
 	// via IPv4 to confirm Prometheus can scrape the local endpoint.
 	// Explicitly asking for an IPv4 listener works.
-	wsl2 := env.WSL2()
-	if wsl2 {
+	if env.WSL2() {
 		networkType = "tcp4"
 	}
 	list, err := net.Listen(networkType, "0.0.0.0:0")


### PR DESCRIPTION
With proper detection of WSL 2 we can give it the special treatment it needs.

### Changes

**On detection of WSL 2**, the following happens:

- Fail fast if cAdvisor is also enabled: it's not supported in WSL 2.
- The check for networking from container to host will listen only on `tcp4` (IPv4). I tested with `tcp` (should be IPv4 and v6) but it ended up only opening a `tcp6` port and the check happens via IPv4, which fails.
- The `hostAddr` is set to `host.docker.local`, as Windows/WSL 2 also use it.
- The `OpenInBrowser` will open the URLs in the Windows browser.

I tested this out in my Windows box and it works flawlessly. 