### PR TITLE
Add stdin as exec option

### DIFF
--- a/env.go
+++ b/env.go
@@ -191,8 +191,17 @@ type runnable interface {
 type ExecOption func(o *ExecOptions)
 
 type ExecOptions struct {
+	Stdin  io.Reader
 	Stdout io.Writer
 	Stderr io.Writer
+}
+
+// WithExecOptionStdin sets stdin reader to be used when exec is performed.
+// By default, it is nil.
+func WithExecOptionStdin(stdin io.Reader) ExecOption {
+	return func(o *ExecOptions) {
+		o.Stdin = stdin
+	}
 }
 
 // WithExecOptionStdout sets stdout writer to be used when exec is performed.

--- a/env_docker.go
+++ b/env_docker.go
@@ -663,7 +663,13 @@ func (d *dockerRunnable) Exec(command Command, opts ...ExecOption) error {
 	args := []string{"exec", d.containerName()}
 	args = append(args, command.Cmd)
 	args = append(args, command.Args...)
+	if o.Stdin != nil {
+		args = append(args[:1], append([]string{"-i"}, args[1:]...)...)
+	}
 	cmd := d.env.exec("docker", args...)
+	if o.Stdin != nil {
+		cmd.Stdin = o.Stdin
+	}
 	cmd.Stdout = o.Stdout
 	cmd.Stderr = o.Stderr
 	return cmd.Run()


### PR DESCRIPTION
Add support to interactively, with `-i` argument, exec in to containers with io.Reader attached to the command as stdin.