### PR TITLE
Use cluster healthcheck as readiness probe for MinIO.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ GIT ?= $(shell which git)
 # Support gsed on OSX (installed via brew), falling back to sed. On Linux
 # systems gsed won't be installed, so will use sed as expected.
 SED ?= $(shell which gsed 2>/dev/null || which sed)
+# Same as above, but for xargs.
+XARGS ?= $(shell which gxargs 2>/dev/null || which xargs)
 
 define require_clean_work_tree
 	@git update-index -q --ignore-submodules --refresh
@@ -119,7 +121,7 @@ lint: $(FAILLINT) $(GOLANGCI_LINT) $(MISSPELL) $(COPYRIGHT) build format docs ch
 		cd $${dir} && $(GOLANGCI_LINT) run; \
 	done
 	@echo ">> detecting misspells"
-	@find . -type f | grep -v vendor/ | grep -vE '\./\..*' | xargs $(MISSPELL) -error
+	@find . -type f | grep -v vendor/ | grep -vE '\./\..*' | $(XARGS) $(MISSPELL) -error
 	@echo ">> ensuring Copyright headers"
-	@$(COPYRIGHT) $(shell go list -f "{{.Dir}}" ./... | xargs -i find "{}" -name "*.go")
+	@$(COPYRIGHT) $(shell go list -f "{{.Dir}}" ./... | $(XARGS) -i find "{}" -name "*.go")
 	$(call require_clean_work_tree,"detected files without copyright - run make lint and commit changes.")

--- a/README.md
+++ b/README.md
@@ -48,20 +48,21 @@ Let's go through an example leveraging the `go test` flow:
 
 4. Use `e2emon.AsInstrumented` if you want to be able to query your service for metrics, which is a great way to assess it's internal state in tests! For example see following Etcd definition:
 
-   ```go mdox-exec="sed -n '231,243p' db/db.go"
+   ```go mdox-exec="sed -n '229,243p' db/db.go"
    	return e2emon.AsInstrumented(env.Runnable(name).WithPorts(map[string]int{AccessPortName: 2379, "metrics": 9000}).Init(
-   		e2e.StartOptions{
-   			Image: o.image,
-   			Command: e2e.NewCommand(
-   				"/usr/local/bin/etcd",
-   				"--listen-client-urls=http://0.0.0.0:2379",
-   				"--advertise-client-urls=http://0.0.0.0:2379",
-   				"--listen-metrics-urls=http://0.0.0.0:9000",
-   				"--log-level=error",
-   			),
-   			Readiness: e2e.NewHTTPReadinessProbe("metrics", "/health", 200, 204),
-   		},
+        e2e.StartOptions{
+            Image: o.image,
+            Command: e2e.NewCommand(
+                "/usr/local/bin/etcd",
+                "--listen-client-urls=http://0.0.0.0:2379",
+                "--advertise-client-urls=http://0.0.0.0:2379",
+                "--listen-metrics-urls=http://0.0.0.0:9000",
+                "--log-level=error",
+            ),
+            Readiness: e2e.NewHTTPReadinessProbe("metrics", "/health", 200, 204),
+        },
    	), "metrics")
+   }
    ```
 
 5. Program your scenario as you want. You can start, wait for their readiness, stop, check their metrics and use their network endpoints from both unit test (`Endpoint`) as well as within each workload (`InternalEndpoint`). You can also access workload directory. There is a shared directory across all workloads. Check `Dir` and `InternalDir` runnable methods.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Let's go through an example leveraging the `go test` flow:
 
 4. Use `e2emon.AsInstrumented` if you want to be able to query your service for metrics, which is a great way to assess it's internal state in tests! For example see following Etcd definition:
 
-   ```go mdox-exec="sed -n '229,243p' db/db.go"
+   ```go mdox-exec="sed -n '228,243p' db/db.go"
    	return e2emon.AsInstrumented(env.Runnable(name).WithPorts(map[string]int{AccessPortName: 2379, "metrics": 9000}).Init(
         e2e.StartOptions{
             Image: o.image,

--- a/db/db.go
+++ b/db/db.go
@@ -80,8 +80,7 @@ func NewMinio(env e2e.Environment, name, bktName string, opts ...Option) *e2emon
 	}
 
 	userID := strconv.Itoa(os.Getuid())
-	const consolePortName = "console"
-	ports := map[string]int{AccessPortName: 8090, consolePortName: 8080}
+	ports := map[string]int{AccessPortName: 8090}
 	envVars := []string{
 		"MINIO_ROOT_USER=" + MinioAccessKey,
 		"MINIO_ROOT_PASSWORD=" + MinioSecretKey,

--- a/db/db.go
+++ b/db/db.go
@@ -85,7 +85,7 @@ func NewMinio(env e2e.Environment, name, bktName string, opts ...Option) *e2emon
 	envVars := []string{
 		"MINIO_ROOT_USER=" + MinioAccessKey,
 		"MINIO_ROOT_PASSWORD=" + MinioSecretKey,
-		"MINIO_BROWSER=" + "on",
+		"MINIO_BROWSER=" + "off",
 		"ENABLE_HTTPS=" + "0",
 	}
 
@@ -114,18 +114,16 @@ func NewMinio(env e2e.Environment, name, bktName string, opts ...Option) *e2emon
 				"sh",
 				"-c",
 				command+fmt.Sprintf(
-					"su - me -s /bin/sh -c 'mkdir -p %s && %s /opt/bin/minio server --address :%v --console-address :%v --quiet %v'",
+					"su - me -s /bin/sh -c 'mkdir -p %s && %s /opt/bin/minio server --address :%v --quiet %v'",
 					filepath.Join(f.Dir(), bktName),
 					strings.Join(envVars, " "),
 					ports[AccessPortName],
-					ports[consolePortName],
 					f.Dir(),
 				),
 			),
-			// Using console as readiness check until MinIO fixes https://github.com/minio/minio/issues/16213.
 			Readiness: e2e.NewHTTPReadinessProbe(
-				consolePortName,
-				"/",
+				AccessPortName,
+				"/minio/health/cluster",
 				200,
 				200,
 			),


### PR DESCRIPTION
This improves on #58 by not needing the console port anymore and truly reflecting MinIO cluster health by definition.