### PR TITLE
env_docker: support docker-in-docker

### DIFF
--- a/env_docker.go
+++ b/env_docker.go
@@ -523,7 +523,15 @@ func (d *dockerRunnable) Endpoint(portName string) string {
 	}
 
 	// Do not use "localhost", because it doesn't work with the AWS DynamoDB client.
-	return fmt.Sprintf("127.0.0.1:%d", localPort)
+	addr := "127.0.0.1"
+	// If we are running inside Docker then 127.0.0.1 is not accessible.
+	// To access the host's network, let's use host.docker.internal.
+	// See: https://docs.docker.com/desktop/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host.
+	if _, err := os.Stat("/.dockerenv"); err == nil {
+		addr = "host.docker.internal"
+	}
+
+	return fmt.Sprintf("%s:%d", addr, localPort)
 }
 
 // InternalEndpoint returns internal service endpoint (host:port) for given internal port.

--- a/env_docker.go
+++ b/env_docker.go
@@ -9,6 +9,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -528,7 +529,10 @@ func (d *dockerRunnable) Endpoint(portName string) string {
 	// To access the host's network, let's use host.docker.internal.
 	// See: https://docs.docker.com/desktop/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host.
 	if _, err := os.Stat("/.dockerenv"); err == nil {
-		addr = "host.docker.internal"
+		dockerAddrs, err := net.LookupIP(dockerGatewayAddr)
+		if err == nil && len(dockerAddrs) > 0 {
+			addr = dockerGatewayAddr
+		}
 	}
 
 	return fmt.Sprintf("%s:%d", addr, localPort)


### PR DESCRIPTION
If we are running e2e tests inside Docker then it's not so straightforward to access host's network. Let's use the special `host.docker.internal` for that.