### PR TITLE
Create a Between MetricValueExpectation

### DIFF
--- a/monitoring/metrics.go
+++ b/monitoring/metrics.go
@@ -201,6 +201,17 @@ func Less(value float64) MetricValueExpectation {
 	}
 }
 
+// Between is a MetricValueExpectation function for WaitSumMetrics that returns true if given single sum is between
+// the lower and upper bounds (non-inclusive, as in `lower < x < upper`).
+func Between(lower, upper float64) MetricValueExpectation {
+	return func(sums ...float64) bool {
+		if len(sums) != 1 {
+			panic("between: expected one value")
+		}
+		return sums[0] > lower && sums[0] < upper
+	}
+}
+
 // EqualsAmongTwo is an isExpected function for WaitSumMetrics that returns true if first sum is equal to the second.
 // NOTE: Be careful on scrapes in between of process that changes two metrics. Those are
 // usually not atomic.


### PR DESCRIPTION
As written in the function's comment, this should help people cover cases like `lower_bound < real_value < upper_bound`