### PR TITLE
Add support for Azurite object storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Let's go through an example leveraging the `go test` flow:
 
 4. Use `e2emon.AsInstrumented` if you want to be able to query your service for metrics, which is a great way to assess it's internal state in tests! For example see following Etcd definition:
 
-   ```go mdox-exec="sed -n '351,363p' db/db.go"
+   ```go mdox-exec="sed -n '462,474p' db/db.go"
    	return e2emon.AsInstrumented(env.Runnable(name).WithPorts(map[string]int{AccessPortName: 2379, "metrics": 9000}).Init(
    		e2e.StartOptions{
    			Image: o.image,


### PR DESCRIPTION
Adds Azurite blob storage and Azure cli runnable to `e2edb`.
Useful for e2e tests involving Azure objstore. 

Can use it with objstore config like,
```
type: AZURE
config:
  storage_account: devstoreaccount1
  storage_connection_string: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
  container: bkt1
  endpoint: 0.0.0.0:10000
```

TODO: Actually write tests with it.