### PR TITLE
monitoring: use instrumented backoff as default for waiting

### DIFF
--- a/monitoring/instrumented_test.go
+++ b/monitoring/instrumented_test.go
@@ -19,6 +19,7 @@ import (
 type runnableFake struct {
 	e2e.Runnable
 
+	running   bool
 	endpoints map[string]string
 }
 
@@ -28,6 +29,22 @@ func (r *runnableFake) InternalEndpoint(portName string) string {
 
 func (r *runnableFake) Endpoint(portName string) string {
 	return r.endpoints[portName]
+}
+
+func (r *runnableFake) IsRunning() bool {
+	return r.running
+}
+
+func (r *runnableFake) SetMetadata(k, v any) {
+}
+
+func (r *runnableFake) Name() string {
+	return "fake"
+}
+
+func (r *runnableFake) Start() error {
+	r.running = true
+	return nil
 }
 
 func TestWaitSumMetric(t *testing.T) {
@@ -86,6 +103,7 @@ metric_b_summary_count 1
 			Max:        600 * time.Millisecond,
 			MaxRetries: 50,
 		})))
+	testutil.Ok(t, r.Start())
 
 	testutil.Ok(t, r.WaitSumMetrics(Equals(221), "metric_a"))
 
@@ -159,6 +177,7 @@ metric_b 1000
 			Max:        600 * time.Millisecond,
 			MaxRetries: 50,
 		})))
+	testutil.Ok(t, r.Start())
 
 	testutil.Ok(t, r.WaitSumMetrics(Equals(math.NaN()), "metric_a"))
 }

--- a/monitoring/metrics.go
+++ b/monitoring/metrics.go
@@ -4,8 +4,8 @@
 package e2emon
 
 import (
+	"context"
 	"math"
-	"time"
 
 	"github.com/efficientgo/core/backoff"
 	"github.com/efficientgo/e2e/monitoring/matchers"
@@ -24,13 +24,13 @@ type metricsOptions struct {
 	labelMatchers      []*matchers.Matcher
 	waitMissingMetrics bool
 	skipMissingMetrics bool
-	waitBackoff        *backoff.Config
+	waitBackoff        *backoff.Backoff
 }
 
 // WithWaitBackoff is an option to configure a backoff when waiting on a metric value.
 func WithWaitBackoff(backoffConfig *backoff.Config) MetricsOption {
 	return func(o *metricsOptions) {
-		o.waitBackoff = backoffConfig
+		o.waitBackoff = backoff.New(context.Background(), *backoffConfig)
 	}
 }
 
@@ -61,21 +61,6 @@ func SkipMissingMetrics() MetricsOption {
 	return func(o *metricsOptions) {
 		o.skipMissingMetrics = true
 	}
-}
-
-func buildMetricsOptions(opts []MetricsOption) metricsOptions {
-	result := metricsOptions{
-		getValue: getMetricValue,
-		waitBackoff: &backoff.Config{
-			Min:        300 * time.Millisecond,
-			Max:        600 * time.Millisecond,
-			MaxRetries: 50,
-		},
-	}
-	for _, opt := range opts {
-		opt(&result)
-	}
-	return result
 }
 
 func getMetricValue(m *io_prometheus_client.Metric) float64 {


### PR DESCRIPTION
* use the instrumented wait backoff of the instrumented runnable as default for waiting for metrics
* composite instrumented options didnt allow overwriting the backoff
* fixing the tests

This makes it possible to set the wait backoff once when creating the runnable. It is not concurrency save but i think it was not to begin with. At least `WaitRemovedMetric` also reused the instrumented runnable wait backoff already. 