### PR TITLE
env: add custom DNS capability

### DIFF
--- a/env.go
+++ b/env.go
@@ -27,8 +27,16 @@ type environmentOptions struct {
 	verbose bool
 	name    string
 
-	volumes []string
-	cpus    string
+	volumes   []string
+	cpus      string
+	dnsServer string
+}
+
+// WithDNS sets DNS server to be used by the environment.
+func WithDNS(dnsServer string) EnvironmentOption {
+	return func(o *environmentOptions) {
+		o.dnsServer = dnsServer
+	}
 }
 
 func WithCPUs(cpus string) EnvironmentOption {

--- a/env_docker.go
+++ b/env_docker.go
@@ -44,7 +44,9 @@ type DockerEnvironment struct {
 
 	hostAddr      string
 	dockerVolumes []string
-	cpus          string
+
+	dnsServer string
+	cpus      string
 
 	registered map[string]struct{}
 	listeners  []EnvironmentListener
@@ -115,6 +117,7 @@ func New(opts ...EnvironmentOption) (_ *DockerEnvironment, err error) {
 		registered:    map[string]struct{}{},
 		dockerVolumes: e.volumes,
 		cpus:          e.cpus,
+		dnsServer:     e.dnsServer,
 	}
 
 	// Force a shutdown in order to cleanup from a spurious situation in case
@@ -316,6 +319,10 @@ func (e *DockerEnvironment) buildDockerRunArgs(name string, ports map[string]int
 
 	if opts.Privileged {
 		args = append(args, "--privileged")
+	}
+
+	if e.dnsServer != "" {
+		args = append(args, "--dns", e.dnsServer)
 	}
 
 	for _, c := range opts.Capabilities {


### PR DESCRIPTION
Add ability to use custom DNS server where /etc/hosts doesn't cut it since it only supports 1:1 mapping.