### PR TITLE
fix: bump default Thanos image to v0.40.1

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           go-version: 1.18.x
 
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -60,7 +60,7 @@ jobs:
           # Configure the Lima guest to forward packets from the col0 bridge to Docker containers.
           limactl shell colima -- sudo iptables -t filter -A FORWARD -s $IP/24 -d 172.0.0.0/8 -j ACCEPT
 
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}

--- a/db/thanos.go
+++ b/db/thanos.go
@@ -13,8 +13,10 @@ import (
 	e2eobs "github.com/efficientgo/e2e/observable"
 )
 
+const thanosImage = "quay.io/thanos/thanos:v0.40.1"
+
 func NewThanosQuerier(env e2e.Environment, name string, endpointsAddresses []string, opts ...Option) *e2eobs.Observable {
-	o := options{image: "quay.io/thanos/thanos:v0.27.0"}
+	o := options{image: thanosImage}
 	for _, opt := range opts {
 		opt(&o)
 	}
@@ -33,7 +35,7 @@ func NewThanosQuerier(env e2e.Environment, name string, endpointsAddresses []str
 		"--query.max-concurrent": "1",
 	}
 	if len(endpointsAddresses) > 0 {
-		args["--store"] = strings.Join(endpointsAddresses, ",")
+		args["--endpoint"] = strings.Join(endpointsAddresses, ",")
 	}
 	if o.flagOverride != nil {
 		args = e2e.MergeFlagsWithoutRemovingEmpty(args, o.flagOverride)
@@ -48,7 +50,7 @@ func NewThanosQuerier(env e2e.Environment, name string, endpointsAddresses []str
 }
 
 func NewThanosSidecar(env e2e.Environment, name string, prom e2e.Linkable, opts ...Option) *e2eobs.Observable {
-	o := options{image: "quay.io/thanos/thanos:v0.27.0"}
+	o := options{image: thanosImage}
 	for _, opt := range opts {
 		opt(&o)
 	}
@@ -78,7 +80,7 @@ func NewThanosSidecar(env e2e.Environment, name string, prom e2e.Linkable, opts 
 }
 
 func NewThanosStore(env e2e.Environment, name string, bktConfigYaml []byte, opts ...Option) *e2eobs.Observable {
-	o := options{image: "quay.io/thanos/thanos:v0.27.0"}
+	o := options{image: thanosImage}
 	for _, opt := range opts {
 		opt(&o)
 	}


### PR DESCRIPTION
This commit also replaces the `--store` argument by `--endpoint` for Thanos Querier. The new argument is available since v0.24.0 but has been removed  in v0.38.0.